### PR TITLE
Support matching author_id and collection_id as both strings and integers

### DIFF
--- a/src/ScraperType/CourseTopicScraper/ScraperModules/ApiUtility.py
+++ b/src/ScraperType/CourseTopicScraper/ScraperModules/ApiUtility.py
@@ -243,8 +243,8 @@ class ApiUtility:
                                         const text = entry[1];
 
                                         // Regular expression to match the author_id and collection_id
-                                        const authorMatch = text.match(/"author_id"\s*:\s*(\d+)/);
-                                        const collectionMatch = text.match(/"collection_id"\s*:\s*(\d+)/);
+                                        const authorMatch = text.match(/["']?author[_I]d["']?:["']?(\d+)["']?/i);
+                                        const collectionMatch = text.match(/["']?collection[_I]d["']?:["']?(\d+)["']?/i);
 
                                         if (authorMatch && collectionMatch) {{
                                             const authorId = String(authorMatch[1]);


### PR DESCRIPTION
#### Summary

Updated the regex patterns used to extract `author_id` and `collection_id` from `text` to handle both quoted (string) and unquoted (integer) formats. This improves compatibility with varied input sources that may represent IDs as either JSON numbers or strings.

#### Changes

```js
- const authorMatch = text.match(/"author_id"\s*:\s*(\d+)/);
- const collectionMatch = text.match(/"collection_id"\s*:\s*(\d+)/);

+ const authorMatch = text.match(/["']?author[_I]d["']?:["']?(\d+)["']?/i);
+ const collectionMatch = text.match(/["']?collection[_I]d["']?:["']?(\d+)["']?/i);
```

#### Rationale

* Some input text may contain IDs as `"author_id": "12345"` instead of `"author_id": 12345`.
* The updated regex handles both styles:

  * With or without quotes around keys and values.
  * Case-insensitive (`i` flag) to support variants like `Author_Id` or `author_Id`.
  * Allows both `"id"` and `"Id"` spelling (for loose key matching tolerance).

#### Impact

This change makes ID extraction more robust to inconsistent JSON formatting and improves parsing reliability without breaking existing behavior.